### PR TITLE
storm-drpc-client-0.1.1 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dist
+dist/*
+storm_drpc_client.egg-info
+storm_drpc_client.egg-info/*

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,1 +1,2 @@
 v0.1.0, 7/3/13 -- Initial release.
+v0.1.1, 7/8/13 -- Fixed README.rst exclusion bug. Fixed git url.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include *.txt
+include *.txt README.rst LICENSE.html
 recursive-include docs *.txt

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-version = '0.1.0'
+version = '0.1.1'
 
 install_requires = [
     'thrift',


### PR DESCRIPTION
...gh url update

Just a .gitignore for the dist tarball and fixed a distribution bug that was excluding the readme and license info. I submitted it to PyPI already and it includes the url fix you put in last week.
