### PR TITLE
Added support for PlainSaslTransportPlugin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 import setuptools
 
-version = '0.1.1'
+version = '0.1.2'
 
 install_requires = [
     'thrift',
+    'thrift_sasl',
     'repoze.lru'
 ]
 

--- a/storm/drpc.py
+++ b/storm/drpc.py
@@ -3,14 +3,18 @@ from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol
 from repoze.lru import lru_cache
 from DistributedRPC import Client
+from sasl_client_transport import SaslClientTransport
 import json
 
+STORM_SASL_SERVICE = 'storm_thrift_server'
+
 class DRPCClient:
-    def __init__(self, host, port=3772, timeout=None, reconnect=False):
+    def __init__(self, host, port=3772, timeout=None, reconnect=False, use_plain_sasl=False):
         self.host = host
         self.port = port
         self.timeout = timeout
         self.reconnect = reconnect
+        self.use_plain_sasl = use_plain_sasl
         if not reconnect:
             self.connect()
 
@@ -18,7 +22,10 @@ class DRPCClient:
         self.socket = TSocket.TSocket(self.host, self.port)
         if self.timeout:
             self.socket.setTimeout(self.timeout)
-        self.transport = TTransport.TFramedTransport(self.socket)
+        if self.use_plain_sasl:
+            self.transport = SaslClientTransport(self.host, self.socket, service=STORM_SASL_SERVICE, mechanism='PLAIN')
+        else:    
+            self.transport = TTransport.TFramedTransport(self.socket)
         self.protocol = TBinaryProtocol.TBinaryProtocol(self.transport)
         self.transport.open()
         self.client = Client(self.protocol)
@@ -39,7 +46,7 @@ class DRPCClient:
 
 
 class DRPCLRUClient(DRPCClient):
-    def __init__(self, host, port=3772, timeout=None, cache_size=50, reconnect=False):
+    def __init__(self, host, port=3772, timeout=None, cache_size=50, reconnect=False, use_plain_sasl=False):
         self.host = host
         self.port = port
         self.timeout = timeout
@@ -47,5 +54,6 @@ class DRPCLRUClient(DRPCClient):
         self.cache = lru_cache(maxsize=cache_size)
         self.execute = self.cache(self.execute)
         self.reconnect = reconnect
+        self.use_plain_sasl = use_plain_sasl
         if not reconnect:
             self.connect()

--- a/storm/sasl_client_transport.py
+++ b/storm/sasl_client_transport.py
@@ -1,0 +1,20 @@
+from thrift_sasl import TSaslClientTransport
+from sasl import Client
+import getpass
+
+class SaslClientTransport(TSaslClientTransport):
+    def __init__(self, host, transport, service=None, mechanism=None):
+        self.host = host
+        self.transport = transport
+        self.service = service
+        self.mechanism = mechanism
+        TSaslClientTransport.__init__(self, self.SaslClientFactory, self.mechanism, transport)
+
+    def SaslClientFactory(self):
+        client = Client()
+        client.setAttr("service", self.service)
+        client.setAttr("host", self.host)
+        client.setAttr("username", getpass.getuser())
+        client.setAttr("password", "password")
+        client.init()
+        return client


### PR DESCRIPTION
As of Storm 1.0.0, SimpleTransportPlugin (which used TFramedTransport) has been deprecated as default insecure transport plugin in favor of PlainSaslTransportPlugin (see [SimpleTransportPlugin API reference](http://storm.apache.org/releases/1.0.0/javadocs/index.html?org/apache/storm/security/auth/SimpleTransportPlugin.html)).  These changes implement support for DRPCClient to talk to a Storm DRPC server that's configured to use PlainSaslTransportPlugin.